### PR TITLE
Fix error variable name

### DIFF
--- a/lib/lita/http_callback.rb
+++ b/lib/lita/http_callback.rb
@@ -31,7 +31,7 @@ module Lita
           if error_handler.arity == 2
             error_handler.call(e, rack_env: env, robot: robot)
           else
-            error_handler.call(error)
+            error_handler.call(e)
           end
 
           raise


### PR DESCRIPTION
Fixes the following error

```

Puma caught this error: undefined local variable or method `error' for #<Lita::HTTPCallback:0x0055f3419a0c10> (NameError)
/artifacts/ruby/2.3.0/bundler/gems/lita-63c0aea70420/lib/lita/http_callback.rb:34:in `rescue in call'
/artifacts/ruby/2.3.0/bundler/gems/lita-63c0aea70420/lib/lita/http_callback.rb:23:in `call'
/artifacts/ruby/2.3.0/gems/http_router-0.11.2/lib/http_router.rb:193:in `process_destination_path'
(eval):567:in `call'
/artifacts/ruby/2.3.0/gems/http_router-0.11.2/lib/http_router.rb:288:in `raw_call'
/artifacts/ruby/2.3.0/bundler/gems/lita-63c0aea70420/lib/lita/rack_app.rb:46:in `call'
/artifacts/ruby/2.3.0/gems/newrelic_rpm-3.18.0.329/lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
/app/lib/spy/http_logger.rb:15:in `call'
/artifacts/ruby/2.3.0/gems/newrelic_rpm-3.18.0.329/lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
/artifacts/ruby/2.3.0/gems/buffered-logger-2.0.0/lib/buffered_logger/middleware.rb:8:in `block in call'
/artifacts/ruby/2.3.0/gems/buffered-logger-2.0.0/lib/buffered_logger.rb:30:in `start'
/artifacts/ruby/2.3.0/gems/buffered-logger-2.0.0/lib/buffered_logger/middleware.rb:8:in `call'
/artifacts/ruby/2.3.0/gems/newrelic_rpm-3.18.0.329/lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
/artifacts/ruby/2.3.0/gems/bugsnag-5.3.2/lib/bugsnag/rack.rb:34:in `call'
/artifacts/ruby/2.3.0/gems/newrelic_rpm-3.18.0.329/lib/new_relic/agent/instrumentation/middleware_tracing.rb:96:in `call'
/artifacts/ruby/2.3.0/gems/puma-3.8.2/lib/puma/server.rb:600:in `handle_request'
/artifacts/ruby/2.3.0/gems/puma-3.8.2/lib/puma/server.rb:435:in `process_client'
/artifacts/ruby/2.3.0/gems/puma-3.8.2/lib/puma/server.rb:299:in `block in run'
/artifacts/ruby/2.3.0/gems/puma-3.8.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'bool(true)
```